### PR TITLE
Correct definition of stacking aperture Fix #17

### DIFF
--- a/Mcrestack.c
+++ b/Mcrestack.c
@@ -10,8 +10,6 @@ License: GPL-3.0 <https://www.gnu.org/licenses/gpl-3.0.txt>.
 
 #include <rsf.h>
 
-#define STACK_APERTURE 100
-
 int main(int argc, char* argv[])
 {
 
@@ -42,6 +40,7 @@ int main(int argc, char* argv[])
 	float **stackedSection; // CRE stacked section
 	int it0, im0, ih, tetai; // loop counter and indexes
 	float sumAmplitudes; // Sum of amplitudes in the stacking
+	int aperture; // Number of offsets to stack
 
 	/* RSF files I/O */  
 	sf_file in, timeCurves, out;
@@ -83,6 +82,13 @@ int main(int argc, char* argv[])
 	if(! sf_getbool("verb",&verb)) verb=0;
 	/* 1: active mode; 0: quiet mode */
 
+	if(!sf_getint("aperture",&aperture)) aperture=1;
+	/* Stacking aperture, number of offsets */
+
+	if(aperture > nh){
+		sf_error("The aperture can't be > n2\nAperture=%i n2=%i",aperture,nh);
+	}
+
 	if (verb) {
 
 		sf_warning("Active mode on!!!");
@@ -111,7 +117,7 @@ int main(int argc, char* argv[])
 
 			sumAmplitudes = 0;
 
-			for(ih=0; ih < STACK_APERTURE; ih++){
+			for(ih=0; ih < aperture; ih++){
 
 				tetai = (int) ((double)creTimeCurve[im0][it0][ih]/dt);
 				sumAmplitudes += creGatherCube[im0][it0][ih][tetai];

--- a/SConstruct
+++ b/SConstruct
@@ -5,7 +5,7 @@ import bldutil
 # Put your name programs in progs variable 
 # without 'M' preffix and '.c' extension
 progs = '''
-vfsacrsnh nhcrssurf
+vfsacrsnh nhcrssurf crestack cretrajec getcregather getcretimecurve
 '''
 
 try:  # distributed version


### PR DESCRIPTION
:outbox_tray: **Pull Request**

**Description**

Correct bug changing the program definition of how many offsets to stack in the input
data cube, determines it can't be greater than number of available
offsets in the data. 

Resolve #17

**Type of change**

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**Add images bellow and aditional context if needed**

It uses variable 'aperture' that a user can define in the command line, and it uses an if test to check if the 'aperture' is not greater than the number of offsets in the data 
