### PR TITLE
Concatenate to build stacked section Resolve #24

### DIFF
--- a/experiments/fullInterpolationAndStack/SConstruct
+++ b/experiments/fullInterpolationAndStack/SConstruct
@@ -23,6 +23,9 @@ from rsf.proj import *
 from creStack import kirchoffModeling as kimod
 from creStack import pefInterpolation as pefin
 
+# Import glob python library
+import glob
+
 # Generate Gaussian reflector model and data cube
 kimod()
 
@@ -151,5 +154,25 @@ for i in range(nm0):
 		crestack timeCurves=${SOURCES[1]} verb=y |
 		put label1=t0 unit1=s label2=m0 unit2=Km --out=stdout
 		''')
+
+# Build the cre stacked section
+# throughout cre stacked traces sorting
+files = glob.glob('creStackedTrace-*.rsf')
+length = len(files)
+
+sortedFiles = []
+for i in range(length):
+	string = 'creStackedTrace-m0-%i.rsf' % i
+	sortedFiles.append(string)  
+
+Flow('stackedSection',sortedFiles,
+	'''
+	rcat axis=2 ${SOURCES[1:%d]} --out=stdout
+	''' % len(files))
+
+Flow('filtStackedSection','stackedSection',
+	'''
+	bandpass fhi=20 --out=stdout
+	''')
 
 End()


### PR DESCRIPTION
:outbox_tray: **Pull Request**

**Description**

Sort and concatenate generated CRE stacked traces to build the CRE
stacked section. Use axis 2 (m0 coordinate to sorting).

Resolve #24 

**Type of change**

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update
