### PR TITLE
Hotfix/issue/38 bug correction in sfgetcregather

### DIFF
--- a/Mgetcregather.c
+++ b/Mgetcregather.c
@@ -98,7 +98,7 @@ int main(int argc, char* argv[])
 		trac_m = (int)((double)m[i]/dm);
 
 		for(j=0;j<nt;j++){
-			creGather[i][j] = t[trac_m][i][j];
+			creGather[i][j] = (trac_m <= nm)? t[trac_m][i][j] : 0.;
 		}
 	}
 

--- a/Mgetcregather.c
+++ b/Mgetcregather.c
@@ -37,6 +37,7 @@ int main(int argc, char* argv[])
 	float cre_o; // CRE Gather axis origin
 	int trac_m; // CMP sample index
 	int aperture; // Number of traces in CRE Gather
+	float mMax; // maximum CMP coordinate of the model
 
 	/* RSF files I/O */  
 	sf_file in, out, out_m, cremh;
@@ -94,11 +95,13 @@ int main(int argc, char* argv[])
 	sf_floatread(m,cre_n,cremh);
 	creGather = sf_floatalloc2(nt,aperture);
 
+	mMax = om+dm*nm;
+
 	for(i=0;i<aperture;i++){
 		trac_m = (int)((double)m[i]/dm);
 
 		for(j=0;j<nt;j++){
-			creGather[i][j] = (trac_m <= nm)? t[trac_m][i][j] : 0.;
+			creGather[i][j] = (m[i] <= mMax)? t[trac_m][i][j] : 0.;
 		}
 	}
 

--- a/experiments/multiLayerModel/cre/SConstruct
+++ b/experiments/multiLayerModel/cre/SConstruct
@@ -40,7 +40,7 @@ dm0 = 0.025
 nm0 = 161
 dataCube='multiLayerDataCube'
 
-for i in range(nm0):
+for i in range(100,102):
 
 	parametersCube = []
 	creGatherCube = []
@@ -78,7 +78,7 @@ for i in range(nm0):
 		#Get CRE Gather from interpolated Data Cube
 		Flow([creGather,creMcoordinate],['interpolatedDataCube2',creMhCoordinates],
 			'''
-			getcregather aperture=50 verb=y cremh=${SOURCES[1]} m=${TARGETS[1]} |
+			getcregather aperture=49 verb=y cremh=${SOURCES[1]} m=${TARGETS[1]} |
                         put label1="Time" unit1="s" label2="Offset" unit2="km" 
 			''')
 
@@ -159,7 +159,7 @@ Flow('filtStackedSection','stackedSection',
 # Show error message if fail
 message = '''
 SConstruct Failed build when m0={m0} and t0={t0}
-'''.format(m0=m0,t0=t0)
+'''.format(m0=(i*dm0+om0),t0=(j*dt0+ot0))
 
 atexit.register(print_build_failures,message)
 


### PR DESCRIPTION
:outbox_tray: **Pull Request**

**Description**

Correct bug in sfgetcregather putting zeroed samples when CMP coordinate of the traces gets out of model bounds.

Resolve #38 

**Type of change**

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

**Add images bellow and aditional context if needed**

CRE trajectories are parabolas in CMP x Offset domain. And CRE gathers are seismic traces above those trajectories. Therefore, CMP increases faster than Offset. So, for a small amount of increasing in Offset coordinate it has a greater increase in CMP coordinate (See the image above. Horizontal axis is CMP, vertical axis is Offset).

![interpolacao0](https://user-images.githubusercontent.com/30205197/83456393-09edf380-a436-11ea-97de-71adedb0c747.png)

Because of that, a CMP coordinate of a trace can be out of the limits of the model in the CMP x Offset plane, despite it has a valid Offset coordinate. This trace will generate an invalid output of a CRE Gather from sfgetcregather, and the bug referenced in this issue will occur.

The solution is when a trace with an invalid CMP coordinate is request to form the CRE Gather, put a zeroed one (zero amplitude trace). The amount of traces in a gather will be the same and zero amplitudes won't affect following processes.

