### PR TITLE
Define aperture=20 for sfgetcregather in the experiments and Resolve #49

### DIFF
--- a/experiments/fullInterpolationAndStack/SConstruct
+++ b/experiments/fullInterpolationAndStack/SConstruct
@@ -97,7 +97,7 @@ for i in range(nm0):
 		#Get CRE Gather from interpolated Data Cube
 		Flow([creGather,creMcoordinate],['interpolatedDataCube2',creMhCoordinates],
 			'''
-			getcregather verb=y cremh=${SOURCES[1]} m=${TARGETS[1]} |
+			getcregather verb=y cremh=${SOURCES[1]} m=${TARGETS[1]} aperture=20 |
                         put label1="Time" unit1="s" label2="Offset" unit2="km" 
 			''')
 

--- a/experiments/fullInterpolationAndStackCDS/SConstruct
+++ b/experiments/fullInterpolationAndStackCDS/SConstruct
@@ -100,7 +100,7 @@ for i in range(nm0):
 		#Get CRE Gather from interpolated Data Cube
 		Flow([creGather,creMcoordinate],['interpolatedDataCube2',creMhCoordinates],
 			'''
-			getcregather verb=y cremh=${SOURCES[1]} m=${TARGETS[1]} |
+			getcregather verb=y cremh=${SOURCES[1]} m=${TARGETS[1]} aperture=20 |
                         put label1="Time" unit1="s" label2="Offset" unit2="km" 
 			''')
 

--- a/experiments/multiLayerModel/cds/SConstruct
+++ b/experiments/multiLayerModel/cds/SConstruct
@@ -79,7 +79,7 @@ for i in range(nm0):
 		#Get CRE Gather from interpolated Data Cube
 		Flow([creGather,creMcoordinate],['interpolatedDataCube2',creMhCoordinates],
 			'''
-			getcregather aperture=50 verb=y cremh=${SOURCES[1]} m=${TARGETS[1]} |
+			getcregather aperture=50 verb=y cremh=${SOURCES[1]} m=${TARGETS[1]} aperture=20 |
                         put label1="Time" unit1="s" label2="Offset" unit2="km" 
 			''')
 

--- a/experiments/multiLayerModel/cre/SConstruct
+++ b/experiments/multiLayerModel/cre/SConstruct
@@ -78,7 +78,7 @@ for i in range(nm0):
 		#Get CRE Gather from interpolated Data Cube
 		Flow([creGather,creMcoordinate],['interpolatedDataCube2',creMhCoordinates],
 			'''
-			getcregather aperture=50 verb=y cremh=${SOURCES[1]} m=${TARGETS[1]} |
+			getcregather aperture=50 verb=y cremh=${SOURCES[1]} m=${TARGETS[1]} aperture=20 |
                         put label1="Time" unit1="s" label2="Offset" unit2="km" 
 			''')
 


### PR DESCRIPTION
:outbox_tray: **Pull Request**

**Description**

Bug correction: The definition of the parameter aperture=20 in the program sfgetcregather will assure that the number of traces in the cre gather will be major than the number of traces to stack defined by aperture=10 in sfcrestack program

Resolve #49 

**Type of change**

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

**Add images bellow and additional context if needed**

